### PR TITLE
feat: Refactor teleclass, Add model embeddings cache after run

### DIFF
--- a/wrench/__init__.py
+++ b/wrench/__init__.py
@@ -1,7 +1,7 @@
 from .catalogger.sddi import SDDICatalogger
 from .common import Pipeline
 from .exceptions import ClassifierError, HarvesterError, WrenchError
-from .grouper.teleclass.core.teleclass import TELEClass
+from .grouper.teleclass.core.teleclass import TELEClassGrouper
 from .harvester.sensorthings import SensorThingsHarvester
 from .types import DocumentType, LocationType
 
@@ -10,7 +10,7 @@ __version__ = "0.1.0"
 __all__ = [
     "Pipeline",
     "SensorThingsHarvester",
-    "TELEClass",
+    "TELEClassGrouper",
     "SDDICatalogger",
     "WrenchError",
     "HarvesterError",

--- a/wrench/grouper/teleclass/core/cache.py
+++ b/wrench/grouper/teleclass/core/cache.py
@@ -1,7 +1,10 @@
 import pickle
 from pathlib import Path
 
-from wrench.grouper.teleclass.core.models import DocumentMeta, EnrichedClass
+import numpy as np
+
+from wrench.grouper.teleclass.core.models import Document, EnrichedClass
+from wrench.log import logger
 
 
 class TELEClassCache:
@@ -25,6 +28,51 @@ class TELEClassCache:
         # Define paths for different cache components
         self.class_terms_path = self.cache_dir / "class_terms.pkl"
         self.assignments_path = self.cache_dir / "assignments.pkl"
+        self.embeddings_path = self.cache_dir / "embeddings.npz"
+
+        self.logger = logger.getChild(self.__class__.__name__)
+
+    def save_class_embeddings(self, enriched_classes: list[EnrichedClass]) -> None:
+        class_names: list[str] = []
+        class_embeddings: list[np.ndarray] = []
+        for cls in enriched_classes:
+            if cls.embeddings is None:
+                raise ValueError("embeddings need to be set before caching")
+
+            class_names.append(cls.class_name)
+            class_embeddings.append(cls.embeddings)
+
+        np.savez_compressed(
+            self.embeddings_path,
+            class_names=class_names,
+            embeddings=class_embeddings,
+        )
+
+    def load_class_embeddings(self) -> list[EnrichedClass]:
+        if not self.embeddings_path.exists():
+            raise FileNotFoundError(
+                "run the TELEClass classifier to generate embeddings"
+            )
+
+        try:
+            data = np.load(self.embeddings_path, allow_pickle=True)
+            class_names = data["class_names"]
+            embeddings = data["embeddings"]
+
+            enriched_classes: list[EnrichedClass] = []
+            for name, embedding in zip(class_names, embeddings):
+                enriched_class = EnrichedClass(
+                    class_name=name,
+                    class_description="",
+                    terms=set(),
+                    embeddings=embedding,
+                )
+                enriched_classes.append(enriched_class)
+
+            return enriched_classes
+        except Exception as e:
+            self.logger.error(f"Error loading class embeddings: {e}")
+            raise ValueError("failed to load embeddings")
 
     def save_class_terms(self, class_terms: list[EnrichedClass]) -> None:
         """Save enriched classes using pickle (due to complex objects)."""
@@ -38,12 +86,12 @@ class TELEClassCache:
                 return pickle.load(f)
         return None
 
-    def save_assignments(self, assignments: list[DocumentMeta]) -> None:
+    def save_assignments(self, assignments: list[Document]) -> None:
         """Save assignments."""
         with open(self.assignments_path, "wb") as f:
             pickle.dump(assignments, f)
 
-    def load_assignments(self) -> list[DocumentMeta]:
+    def load_assignments(self) -> list[Document]:
         """Load assignments if they exist, converting lists back to sets."""
         assignments = []
 

--- a/wrench/grouper/teleclass/core/config.py
+++ b/wrench/grouper/teleclass/core/config.py
@@ -10,7 +10,7 @@ class LLMConfig(BaseModel):
 
     host: str = Field(description="LLM service host URL")
     model: str = Field(description="Model to use for LLM enrichment")
-    prompt: str = Field(
+    prompt: str | None = Field(
         default=None, description="Prompt to generate key terms for enrichment"
     )
     temperature: float = Field(
@@ -30,9 +30,6 @@ class EmbeddingConfig(BaseModel):
 class CorpusConfig(BaseModel):
     """Configuration for corpus enrichment."""
 
-    phrase_extractor: str = Field(
-        default="yake", description="Phrase extraction method (keybert or yake)"
-    )
     top_n: int = Field(default=5, description="Number of top phrases to extract")
 
 

--- a/wrench/grouper/teleclass/core/document_loader.py
+++ b/wrench/grouper/teleclass/core/document_loader.py
@@ -5,12 +5,12 @@ from typing import Protocol, Union
 from pydantic import BaseModel
 from sentence_transformers import SentenceTransformer
 
-from wrench.grouper.teleclass.core.models import DocumentMeta
+from wrench.grouper.teleclass.core.models import Document
 from wrench.models import Item
 
 
 class DocumentLoader(Protocol):
-    def load(self, encoder: SentenceTransformer) -> list[DocumentMeta]:
+    def load(self, encoder: SentenceTransformer) -> list[Document]:
         pass
 
 
@@ -42,7 +42,7 @@ class JSONDocumentLoader:
         """
         self.file_path = Path(file_path)
 
-    def load(self, encoder: SentenceTransformer) -> list[DocumentMeta]:
+    def load(self, encoder: SentenceTransformer) -> list[Document]:
         if not self.file_path.exists():
             raise FileNotFoundError(f"JSON file not found: {self.file_path}")
 
@@ -53,10 +53,10 @@ class JSONDocumentLoader:
             raise ValueError("JSON file must contain a list of documents")
 
         return [
-            DocumentMeta(
+            Document(
                 id=str(idx),
                 content=json.dumps(doc),
-                embeddings=encoder.encode(json.dumps(doc)),
+                embeddings=encoder.encode(json.dumps(doc), convert_to_numpy=True),
             )
             for idx, doc in enumerate(data)
         ]
@@ -95,12 +95,12 @@ class ModelDocumentLoader:
             raise TypeError("documents must be a list of Item instances")
         self.documents = documents
 
-    def load(self, encoder: SentenceTransformer) -> list[DocumentMeta]:
+    def load(self, encoder: SentenceTransformer) -> list[Document]:
         return [
-            DocumentMeta(
+            Document(
                 id=doc.id,
                 content=doc.model_dump_json(),
-                embeddings=encoder.encode(doc.model_dump_json()),
+                embeddings=encoder.encode(doc.model_dump_json(), convert_to_numpy=True),
             )
             for doc in self.documents
         ]

--- a/wrench/grouper/teleclass/core/models.py
+++ b/wrench/grouper/teleclass/core/models.py
@@ -6,10 +6,10 @@ from pydantic import BaseModel, ConfigDict, computed_field
 T = TypeVar("T", bound=BaseModel)
 
 
-class DocumentMeta(BaseModel):
+class Document(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    id: str | None = ""
-    embeddings: np.ndarray | None = None
+    id: str = ""
+    embeddings: np.ndarray
     content: str
     # Core classes set after LLM enrichment
     core_classes: set[str] | None = None
@@ -68,12 +68,12 @@ class EnrichmentResult(BaseModel):
 
 
 class LLMEnrichmentResult(EnrichmentResult):
-    # Stores LLM enrichment results, such as classes with its relevant terms, and each document's core classes
-    DocumentCoreClasses: list[DocumentMeta]
+    # Stores LLM enrichment results, such as classes with its relevant terms, and each document's core classes.
+    DocumentCoreClasses: list[Document]
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def result(self) -> tuple[list[EnrichedClass], list[DocumentMeta]]:
+    def result(self) -> tuple[list[EnrichedClass], list[Document]]:
         return self.ClassEnrichment, self.DocumentCoreClasses
 
 

--- a/wrench/grouper/teleclass/core/taxonomy_manager.py
+++ b/wrench/grouper/teleclass/core/taxonomy_manager.py
@@ -2,16 +2,14 @@ from typing import Any
 
 import networkx as nx
 
-from .config import TELEClassConfig
-
 
 class TaxonomyManager:
     """Manages taxonomy operations and caching."""
 
     @classmethod
-    def from_config(cls, config: TELEClassConfig) -> "TaxonomyManager":
+    def from_config(cls, taxonomy: list[dict[str, Any]]) -> "TaxonomyManager":
         """Create from TELEClassConfig."""
-        graph = cls._build_graph(config.taxonomy)
+        graph = cls._build_graph(taxonomy)
         return cls(graph)
 
     @staticmethod
@@ -40,9 +38,14 @@ class TaxonomyManager:
                         children = item.get("children", [])
                     else:
                         # Traditional format with single key and children
-                        node_name = next(iter(item.keys()))
-                        description = ""
-                        children = item[node_name]
+                        try:
+                            node_name = next(iter(item.keys()))
+                            description = ""
+                            children = item[node_name]
+                        except (StopIteration, AttributeError) as e:
+                            raise ValueError(
+                                f"Invalid taxonomy node structure: {str(e)}"
+                            ) from e
 
                     # Add edge from parent to current node
                     G.add_edge(parent, node_name)

--- a/wrench/grouper/teleclass/enrichment/base.py
+++ b/wrench/grouper/teleclass/enrichment/base.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+
+from wrench.grouper.teleclass.core.models import (
+    Document,
+    EnrichedClass,
+    EnrichmentResult,
+)
+
+
+class Enricher(ABC):
+    @abstractmethod
+    def enrich(
+        self, enriched_classes: list[EnrichedClass], collection: list[Document]
+    ) -> EnrichmentResult:
+        pass


### PR DESCRIPTION
### Description

## Changes proposed in this pull request (what was done and why):
- Cache model embeddings after run
- Use cached embeddings in Similarity classifier

Changes refer to particular issues, PRs or documents:

Traceability

- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the Related Issues section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.
